### PR TITLE
Change URLs of sites redirecting to SSL to https

### DIFF
--- a/Scripts/index.js
+++ b/Scripts/index.js
@@ -1065,7 +1065,7 @@ $(function ()
 		        }
 		        //window.location = location.protocol + '//' + domain + '/MapClick.php' + query;
 		        //Url = location.protocol + '//' + domain + '/MapClick.php' + query;
-		        Url =  'http://' + domain + '/MapClick.php' + query;
+		        Url =  'https://' + domain + '/MapClick.php' + query;
 		    }
 		    Url = "cors/?u=" + encodeURIComponent(Url);
 

--- a/Scripts/twc1.js
+++ b/Scripts/twc1.js
@@ -149,7 +149,7 @@ var GetNoaaLatLng = function ()
 {
     //http://forecast.weather.gov/zipcity.php?inputstring=
     var Address = txtAddress.val();
-    var Url = "http://forecast.weather.gov/zipcity.php?inputstring=" + Address;
+    var Url = "https://forecast.weather.gov/zipcity.php?inputstring=" + Address;
 
     var xhr;
     var _orgAjax = jQuery.ajaxSettings.xhr;
@@ -172,7 +172,7 @@ var GetNoaaLatLng = function ()
 
             var ResponseURL = xhr.responseURL;
 
-            if (ResponseURL.startsWith("http://forecast.weather.gov/zipcity.php?inputstring=") == true)
+            if (ResponseURL.startsWith("https://forecast.weather.gov/zipcity.php?inputstring=") == true)
             {
                 alert("Invalid query");
                 return;
@@ -259,7 +259,7 @@ var getParameterByName = function (name, url)
 
 var GetCurrentWeather = function(WeatherParameters)
 {
-    var Url = "http://forecast.weather.gov/MapClick.php?FcstType=dwml";
+    var Url = "https://forecast.weather.gov/MapClick.php?FcstType=dwml";
     Url += "&lat=" + WeatherParameters.Latitude.toString();
     Url += "&lon=" + WeatherParameters.Longitude.toString();
     Url = "cors/?u=" + encodeURIComponent(Url);
@@ -698,7 +698,7 @@ var GetWeatherMetar = function (WeatherParameters)
 
 var GetWeatherForecast = function (WeatherParameters)
 {
-    var Url = "http://tgftp.nws.noaa.gov/data/forecasts/zone/";
+    var Url = "https://tgftp.nws.noaa.gov/data/forecasts/zone/";
     Url += WeatherParameters.ZoneId.substr(0, 2).toLowerCase() + "/";
     Url += WeatherParameters.ZoneId.toLowerCase() + ".txt";
     //Url += "," + (new Date().getTime()); // Prevents caching

--- a/Scripts/twc1.js
+++ b/Scripts/twc1.js
@@ -330,7 +330,7 @@ var GetClosestCurrentWeather = function (WeatherParameters, Distance)
     }
 
     // Get the current weather from the next closest station.
-    var Url = "http://www.aviationweather.gov/adds/dataserver_current/httpparam?datasource=metars&requesttype=retrieve&format=xml&hoursBeforeNow=1";
+    var Url = "https://www.aviationweather.gov/adds/dataserver_current/httpparam?datasource=metars&requesttype=retrieve&format=xml&hoursBeforeNow=1";
     Url += "&radialDistance=" + Distance.toString();
     Url += ";" + WeatherParameters.Longitude;
     Url += "," + WeatherParameters.Latitude;
@@ -636,7 +636,7 @@ var GetWeatherHazards = function (WeatherParameters)
 
 var GetWeatherMetar = function (WeatherParameters)
 {
-    var Url = "http://www.aviationweather.gov/adds/dataserver_current/httpparam?datasource=metars&requesttype=retrieve&format=xml&hoursBeforeNow=3";
+    var Url = "https://www.aviationweather.gov/adds/dataserver_current/httpparam?datasource=metars&requesttype=retrieve&format=xml&hoursBeforeNow=3";
     Url += "&stationString=" + WeatherParameters.StationId;
     //Url += "," + (new Date().getTime()); // Prevents caching
     //Url = "https://crossorigin.me/" + Url; // Need to do this for Chrome and CORS
@@ -2702,7 +2702,7 @@ var GetRegionalStations = function (WeatherParameters, Distance)
         WeatherParameters.WeatherCurrentRegionalConditions = new WeatherCurrentRegionalConditions();
     }
 
-    var Url = "http://www.aviationweather.gov/adds/dataserver_current/httpparam?datasource=metars&requesttype=retrieve&format=xml&hoursBeforeNow=1";
+    var Url = "https://www.aviationweather.gov/adds/dataserver_current/httpparam?datasource=metars&requesttype=retrieve&format=xml&hoursBeforeNow=1";
     Url += "&radialDistance=" + Distance.toString();
     Url += ";" + WeatherParameters.Longitude;
     Url += "," + WeatherParameters.Latitude;
@@ -3064,7 +3064,7 @@ var ShowRegionalMap = function (WeatherParameters, TomorrowForecast)
             var maxLon = MinMaxLatLon.MaxLongitude;
             var minLon = MinMaxLatLon.MinLongitude;
 
-            var Url = "http://www.aviationweather.gov/adds/dataserver_current/httpparam?dataSource=metars&requestType=retrieve&format=xml&hoursBeforeNow=1&minLon=" + minLon + "&minLat=" + minLat + "&maxLon=" + maxLon + "&maxLat=" + maxLat;
+            var Url = "https://www.aviationweather.gov/adds/dataserver_current/httpparam?dataSource=metars&requestType=retrieve&format=xml&hoursBeforeNow=1&minLon=" + minLon + "&minLat=" + minLat + "&maxLon=" + maxLon + "&maxLat=" + maxLat;
 
             //var Gif = new SuperGif({
             //    src: 'images/sunny.gif',
@@ -3273,7 +3273,7 @@ var ShowRegionalMap = function (WeatherParameters, TomorrowForecast)
                         return;
                     }
 
-                    var Url = "http://www.aviationweather.gov/adds/dataserver_current/httpparam?datasource=metars&requesttype=retrieve&format=xml&hoursBeforeNow=3";
+                    var Url = "https://www.aviationweather.gov/adds/dataserver_current/httpparam?datasource=metars&requesttype=retrieve&format=xml&hoursBeforeNow=3";
                     Url += "&stationString=" + GetStationIdFromUrl(weatherDwmlParser.data_current_observations.moreWeatherInformation.value);
                     Url = "cors/?u=" + encodeURIComponent(Url);
 

--- a/Scripts/twc1.js
+++ b/Scripts/twc1.js
@@ -2547,7 +2547,7 @@ var GetTravelWeather = function (TravelCities)
     {
         var TravelCity = this;
 
-        var Url = "http://forecast.weather.gov/MapClick.php?FcstType=dwml";
+        var Url = "https://forecast.weather.gov/MapClick.php?FcstType=dwml";
         Url += "&lat=" + TravelCity.Latitude.toString();
         Url += "&lon=" + TravelCity.Longitude.toString();
         Url = "cors/?u=" + encodeURIComponent(Url);
@@ -2852,7 +2852,7 @@ var GetDwmlRegionalStations = function (WeatherParameters, Distance)
             return true;
         }
 
-        var Url = "http://forecast.weather.gov/MapClick.php?FcstType=dwml";
+        var Url = "https://forecast.weather.gov/MapClick.php?FcstType=dwml";
         Url += "&lat=" + _WeatherMetarsParser.data_METAR.latitude.toString();
         Url += "&lon=" + _WeatherMetarsParser.data_METAR.longitude.toString();
         Url = "cors/?u=" + encodeURIComponent(Url);
@@ -3187,7 +3187,7 @@ var ShowRegionalMap = function (WeatherParameters, TomorrowForecast)
             });
             SkipCities.push(RegionalCity);
 
-            var Url = "http://forecast.weather.gov/MapClick.php?FcstType=dwml";
+            var Url = "https://forecast.weather.gov/MapClick.php?FcstType=dwml";
             Url += "&lat=" + RegionalCity.Latitude.toString();
             Url += "&lon=" + RegionalCity.Longitude.toString();
             Url = "cors/?u=" + encodeURIComponent(Url);

--- a/Scripts/twc3.js
+++ b/Scripts/twc3.js
@@ -3070,7 +3070,7 @@ var GetWeatherMetar = function (WeatherParameters)
 
 var GetWeatherForecast = function (WeatherParameters)
 {
-    var Url = "http://tgftp.nws.noaa.gov/data/forecasts/zone/";
+    var Url = "https://tgftp.nws.noaa.gov/data/forecasts/zone/";
     Url += WeatherParameters.ZoneId.substr(0, 2).toLowerCase() + "/";
     Url += WeatherParameters.ZoneId.toLowerCase() + ".txt";
     //Url += "," + (new Date().getTime()); // Prevents caching

--- a/Scripts/twc3.js
+++ b/Scripts/twc3.js
@@ -1294,14 +1294,14 @@ var GetOutlook = function (WeatherParameters)
         GetTideInfo2(WeatherParameters);
     };
 
-    var TempUrl = "http://www.cpc.ncep.noaa.gov/products/predictions/30day/off14_temp.gif";
+    var TempUrl = "https://www.cpc.ncep.noaa.gov/products/predictions/30day/off14_temp.gif";
     TempUrl = "cors/?u=" + encodeURIComponent(TempUrl);
     var TempImage = new Image();
     TempImage.onload = ImageOnLoad;
     TempImage.onerror = ImageOnError;
     TempImage.src = TempUrl;
 
-    var PrcpUrl = "http://www.cpc.ncep.noaa.gov/products/predictions/30day/off14_prcp.gif";
+    var PrcpUrl = "https://www.cpc.ncep.noaa.gov/products/predictions/30day/off14_prcp.gif";
     PrcpUrl = "cors/?u=" + encodeURIComponent(PrcpUrl);
     var PrcpImage = new Image();
     PrcpImage.onload = ImageOnLoad;

--- a/Scripts/twc3.js
+++ b/Scripts/twc3.js
@@ -353,7 +353,7 @@ var GetClosestCurrentWeather = function (WeatherParameters, Distance)
     }
 
     // Get the current weather from the next closest station.
-    var Url = "http://www.aviationweather.gov/adds/dataserver_current/httpparam?datasource=metars&requesttype=retrieve&format=xml&hoursBeforeNow=1";
+    var Url = "https://www.aviationweather.gov/adds/dataserver_current/httpparam?datasource=metars&requesttype=retrieve&format=xml&hoursBeforeNow=1";
     Url += "&radialDistance=" + Distance.toString();
     Url += ";" + WeatherParameters.Longitude;
     Url += "," + WeatherParameters.Latitude;
@@ -3013,7 +3013,7 @@ var GetWeatherHazards3 = function (WeatherParameters)
 
 var GetWeatherMetar = function (WeatherParameters)
 {
-    var Url = "http://www.aviationweather.gov/adds/dataserver_current/httpparam?datasource=metars&requesttype=retrieve&format=xml&hoursBeforeNow=3";
+    var Url = "https://www.aviationweather.gov/adds/dataserver_current/httpparam?datasource=metars&requesttype=retrieve&format=xml&hoursBeforeNow=3";
     Url += "&stationString=" + WeatherParameters.StationId;
     //Url += "," + (new Date().getTime()); // Prevents caching
     //Url = "https://crossorigin.me/" + Url; // Need to do this for Chrome and CORS
@@ -9188,7 +9188,7 @@ var GetRegionalStations = function (WeatherParameters, Distance)
         WeatherParameters.WeatherCurrentRegionalConditions = new WeatherCurrentRegionalConditions();
     }
 
-    var Url = "http://www.aviationweather.gov/adds/dataserver_current/httpparam?datasource=metars&requesttype=retrieve&format=xml&hoursBeforeNow=1";
+    var Url = "https://www.aviationweather.gov/adds/dataserver_current/httpparam?datasource=metars&requesttype=retrieve&format=xml&hoursBeforeNow=1";
     Url += "&radialDistance=" + Distance.toString();
     Url += ";" + WeatherParameters.Longitude;
     Url += "," + WeatherParameters.Latitude;
@@ -10025,7 +10025,7 @@ var ShowRegionalMap = function (WeatherParameters, TomorrowForecast1, TomorrowFo
             var maxLon = MinMaxLatLon.MaxLongitude - 1; // Prevent cities from being cut off on the right side.
             var minLon = MinMaxLatLon.MinLongitude;
 
-            var Url = "http://www.aviationweather.gov/adds/dataserver_current/httpparam?dataSource=metars&requestType=retrieve&format=xml&hoursBeforeNow=1&minLon=" + minLon + "&minLat=" + minLat + "&maxLon=" + maxLon + "&maxLat=" + maxLat;
+            var Url = "https://www.aviationweather.gov/adds/dataserver_current/httpparam?dataSource=metars&requestType=retrieve&format=xml&hoursBeforeNow=1&minLon=" + minLon + "&minLat=" + minLat + "&maxLon=" + maxLon + "&maxLat=" + maxLat;
 
             if (DontLoadGifs == true)
             {
@@ -10282,7 +10282,7 @@ var ShowRegionalMap = function (WeatherParameters, TomorrowForecast1, TomorrowFo
                         return;
                     }
 
-                    var Url = "http://www.aviationweather.gov/adds/dataserver_current/httpparam?datasource=metars&requesttype=retrieve&format=xml&hoursBeforeNow=3";
+                    var Url = "https://www.aviationweather.gov/adds/dataserver_current/httpparam?datasource=metars&requesttype=retrieve&format=xml&hoursBeforeNow=3";
                     Url += "&stationString=" + GetStationIdFromUrl(weatherDwmlParser.data_current_observations.moreWeatherInformation.value);
                     //Url = "cors/?u=" + encodeURIComponent(Url);
 
@@ -10755,7 +10755,7 @@ var ShowDopplerMap = function (WeatherParameters)
 
         // Find the most current doppler radar image.
         //var Url = "http://radar.weather.gov/Conus/RadarImg/mosaic_times.txt";
-        var Url = "http://radar.weather.gov/Conus/RadarImg";
+        var Url = "https://radar.weather.gov/Conus/RadarImg";
         //Url = "cors/?u=" + encodeURIComponent(Url);
 
         //var TimesMax = 6;
@@ -10807,7 +10807,7 @@ var ShowDopplerMap = function (WeatherParameters)
                 for (var Index = UrlsUnd; Index > UrlsUnd - _DopplerRadarImageMax; Index--)
                 {
                     //http://radar.weather.gov/Conus/RadarImg/Conus_20161004_0028_N0Ronly.gif
-                    var Url = "http://radar.weather.gov/Conus/RadarImg/";
+                    var Url = "https://radar.weather.gov/Conus/RadarImg/";
                     Url += $(Urls[Index]).attr("href");
                     Url = "cors/?u=" + encodeURIComponent(Url);
 


### PR DESCRIPTION
A couple of the weather sites are redirecting to SSL now. Call `https` directly and save the round-trip, as well as keeping more strict CORS relays happy.