### PR TITLE
add fixed name 'latest' radar image

### DIFF
--- a/Scripts/twc3.js
+++ b/Scripts/twc3.js
@@ -10903,7 +10903,7 @@ var ShowDopplerMap = function (WeatherParameters)
 
         // Find the most current doppler radar image.
         //var Url = "http://radar.weather.gov/Conus/RadarImg/mosaic_times.txt";
-        var Url = "https://radar.weather.gov/Conus/RadarImg";
+        var Url = "https://radar.weather.gov/Conus/RadarImg/";
         //Url = "cors/?u=" + encodeURIComponent(Url);
 
         //var TimesMax = 6;
@@ -10944,12 +10944,14 @@ var ShowDopplerMap = function (WeatherParameters)
                 if (WeatherParameters.State == "HI")
                 {
                     var Urls = $text.find("a[href*='hawaii_']");
-                    var UrlsUnd = Urls.length - 3;
+                    var UrlsUnd = Urls.length - 4;
+                    var latest = "https://radar.weather.gov/Conus/RadarImg/hawaii_radaronly.gif";
                 }
                 else
                 {
                     var Urls = $text.find("a[href*='Conus_']");
-                    var UrlsUnd = Urls.length - 1;
+                    var UrlsUnd = Urls.length - 2;
+                    var latest = "https://radar.weather.gov/Conus/RadarImg/latest_radaronly.gif";
                 }
 
                 for (var Index = UrlsUnd; Index > UrlsUnd - _DopplerRadarImageMax; Index--)
@@ -10961,6 +10963,8 @@ var ShowDopplerMap = function (WeatherParameters)
 
                     RadarUrls.push(Url);
                 }
+                // add the fixed named latest image
+                RadarUrls.push("cors/?u=" + encodeURIComponent(latest));
 
                 // Load the most recent doppler radar images.
                 $(RadarUrls).each(function (Index, Value)


### PR DESCRIPTION
After looking through https://radar.weather.gov/Conus/RadarImg/ I found that in addition to the timestamped files there is a newer file with the name 'latest...'. It took a bit of comparing the images side by side and looking at the last-modified headers to confirm this. The timestamp shown on the RadarImg listing does not appear to reflect the last-modified date returned with the file.

Additionally I added the trailing slash to the url. Without this the CORS server has to follow a 301 redirect adding an unnecessary round trip to the loading time.