### PR TITLE
Remove geoquery when working from a saved location close #85

### DIFF
--- a/Scripts/index.js
+++ b/Scripts/index.js
@@ -58,6 +58,7 @@ var btnScrollRss;
 var chkScrollHazardText;
 
 //var _InFullScreen = false;
+var _AutoSelectQuery = false;
 var _TwcDataUrl = "";
 var _IsPlaying = false;
 
@@ -1329,6 +1330,14 @@ $(function ()
         dataType: 'jsonp',
         transformResult: function (response)
         {
+					if (_AutoSelectQuery == true)
+					{
+							_AutoSelectQuery = false;
+							window.setTimeout(function ()
+							{
+									$(ac.suggestionsContainer.children[0]).click();
+							}, 1);
+					}
             return {
                 suggestions: $.map(response.suggestions, function (i)
                 {
@@ -1374,6 +1383,7 @@ $(function ()
     {
         console.log(TwcQueryStr);
         TwcQuery = TwcQueryStr;
+				TwcLatLon = undefined;
     }
 
     if (TwcQuery)
@@ -1382,10 +1392,17 @@ $(function ()
         TwcQuery = TwcQuery.replace(/ *\([^)]*\) */g, "");
     }
 		spanLastRefresh = $("#spanLastRefresh");
-    if (TwcQuery && TwcLatLon)
+    if (TwcQuery)
     {
 			txtAddress.val(TwcQuery);
-			doRedirectToGeometry(JSON.parse(TwcLatLon));
+			if (TwcLatLon) {
+				doRedirectToGeometry(JSON.parse(TwcLatLon));
+
+			} else {
+				_AutoSelectQuery = true;
+				txtAddress.blur();
+				txtAddress.focus();
+			}
     }
 
     var TwcPlay = localStorage.getItem("TwcPlay");

--- a/Scripts/index.js
+++ b/Scripts/index.js
@@ -58,7 +58,6 @@ var btnScrollRss;
 var chkScrollHazardText;
 
 //var _InFullScreen = false;
-var _AutoSelectQuery = false;
 var _TwcDataUrl = "";
 var _IsPlaying = false;
 
@@ -1269,7 +1268,7 @@ $(function ()
 
 		    // Save the query
 		    localStorage.setItem("TwcQuery", txtAddress.val());
-
+				localStorage.setItem("TwcLatLon", JSON.stringify(geom))
 		};
 
     var PreviousSeggestionValue = null;
@@ -1330,15 +1329,6 @@ $(function ()
         dataType: 'jsonp',
         transformResult: function (response)
         {
-            if (_AutoSelectQuery == true)
-            {
-                _AutoSelectQuery = false;
-                window.setTimeout(function ()
-                {
-                    $(ac.suggestionsContainer.children[0]).click();
-                }, 1);
-            }
-
             return {
                 suggestions: $.map(response.suggestions, function (i)
                 {
@@ -1377,6 +1367,7 @@ $(function ()
 
     // Auto load the previous query
     var TwcQuery = localStorage.getItem("TwcQuery");
+    var TwcLatLon = localStorage.getItem("TwcLatLon");
 
     var TwcQueryStr = getParameterByName("location");
     if (TwcQueryStr)
@@ -1390,13 +1381,11 @@ $(function ()
         // Remove "(...)"
         TwcQuery = TwcQuery.replace(/ *\([^)]*\) */g, "");
     }
-
-    if (TwcQuery)
+		spanLastRefresh = $("#spanLastRefresh");
+    if (TwcQuery && TwcLatLon)
     {
-        _AutoSelectQuery = true;
-        txtAddress.val(TwcQuery);
-        txtAddress.blur();
-        txtAddress.focus();
+			txtAddress.val(TwcQuery);
+			doRedirectToGeometry(JSON.parse(TwcLatLon));
     }
 
     var TwcPlay = localStorage.getItem("TwcPlay");
@@ -1492,6 +1481,7 @@ $(function ()
         _IsPlaying = true;
 
         localStorage.removeItem("TwcQuery");
+        localStorage.removeItem("TwcLatLon");
         PreviousSeggestionValue = null;
         PreviousSeggestion = null;
 
@@ -1544,7 +1534,6 @@ $(function ()
     });
 
     divRefresh = $("#divRefresh");
-    spanLastRefresh = $("#spanLastRefresh");
     chkAutoRefresh = $("#chkAutoRefresh");
     lblRefreshCountDown = $("#lblRefreshCountDown");
     spanRefreshCountDown = $("#spanRefreshCountDown");


### PR DESCRIPTION
I was able to remove 2 of the 3 geoquery api calls when using the last location stored in 1localStorage1. This is accomplished by adding a new item to `localStorage`: `'TwcLatLon'`.

The third one is a call to the reverse geocode to get the zip code. It could be stored and re-used as well, but it wasn't something that I had tackled in my fork so I didn't try to remove it yet.

The `spanLastRefresh` had to be moved to it's new location to resolve a race condition exposed by not needing to wait for the two round trips to the geocode server. The `_AutoSelectQuery` variable and code was also removed as it is no longer needed.